### PR TITLE
Add initial Terraform configuration with BPG Proxmox provider

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,7 @@
+provider "proxmox" {
+  pm_api_url          = var.pm_api_url
+  pm_user             = var.pm_user
+  pm_password         = var.pm_password
+  pm_api_token_id     = var.pm_api_token_id
+  pm_api_token_secret = var.pm_api_token_secret
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+pm_api_url   = "https://proxmox.example.com:8006/api2/json"
+pm_user      = "root@pam"
+pm_password  = "password"
+# pm_api_token_id     = "root@pam!mytoken"
+# pm_api_token_secret = "tokensecret"
+
+cluster_name  = "pve"
+template_name = "debian-template"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,40 @@
+variable "pm_api_url" {
+  description = "Proxmox API URL"
+  type        = string
+}
+
+variable "pm_user" {
+  description = "Proxmox user"
+  type        = string
+}
+
+variable "pm_password" {
+  description = "Proxmox password"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "pm_api_token_id" {
+  description = "Proxmox API token ID"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "pm_api_token_secret" {
+  description = "Proxmox API token secret"
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "cluster_name" {
+  description = "Proxmox cluster name"
+  type        = string
+}
+
+variable "template_name" {
+  description = "VM template name"
+  type        = string
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    proxmox = {
+      source  = "bpg/proxmox"
+      version = ">= 0.0.1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- configure Terraform Proxmox provider to use `bpg/proxmox`
- expose token ID and secret variables alongside user/password
- provide example tfvars for either auth method

## Testing
- `apt-get update` *(fails: repository InRelease not signed)*
- `wget https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_linux_amd64.zip -O /tmp/terraform.zip` *(fails: Proxy tunneling failed: Forbidden)*
- `terraform fmt -check terraform` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c630022c8331a5e728b25cc66d57