### PR TITLE
adiciona módulo vm-qemu com suporte a cloud-init

### DIFF
--- a/terraform/modules/vm-qemu/README.md
+++ b/terraform/modules/vm-qemu/README.md
@@ -1,0 +1,75 @@
+# Módulo Terraform: vm-qemu
+
+Cria uma VM no Proxmox a partir de uma imagem cloud baixada no momento do `apply`, gerando automaticamente um ISO de Cloud-Init para configuração inicial.
+
+Requer que o host Proxmox tenha o utilitário `cloud-localds` instalado.
+
+## Exemplo de uso
+```hcl
+module "vm_qemu" {
+  source       = "./modules/vm-qemu"
+  pm_host      = "192.168.1.10"
+  pm_user      = "root"
+  pm_password  = var.pm_password
+  name         = "servidor01"
+  vmid         = 101
+  cores        = 2
+  memory       = 2048
+  disk_size    = "20G"
+  storage      = "local-lvm"
+  bridge       = "vmbr0"
+  ip_address   = "192.168.1.50"
+  cidr         = 24
+  gateway      = "192.168.1.1"
+  ssh_key      = file("~/.ssh/id_rsa.pub")
+  user         = "debian"
+  image_url    = "https://cloud-images.debian.org/debian-12-genericcloud-amd64.qcow2"
+  image_name   = "debian-12-genericcloud-amd64.qcow2"
+}
+```
+
+## Criando várias VMs
+É possível definir um conjunto de VMs em um `local` e criar todas com `for_each`:
+
+```hcl
+locals {
+  vms = {
+    srv1 = {
+      name       = "srv1"
+      vmid       = 101
+      ip_address = "192.168.1.51"
+    }
+    srv2 = {
+      name       = "srv2"
+      vmid       = 102
+      ip_address = "192.168.1.52"
+    }
+  }
+}
+
+module "vm_qemu" {
+  for_each    = local.vms
+  source      = "./modules/vm-qemu"
+  pm_host     = "192.168.1.10"
+  pm_user     = "root"
+  pm_password = var.pm_password
+  name        = each.value.name
+  vmid        = each.value.vmid
+  cores       = 2
+  memory      = 2048
+  disk_size   = "20G"
+  storage     = "local-lvm"
+  bridge      = "vmbr0"
+  ip_address  = each.value.ip_address
+  cidr        = 24
+  gateway     = "192.168.1.1"
+  ssh_key     = file("~/.ssh/id_rsa.pub")
+  user        = "debian"
+  image_url   = "https://cloud-images.debian.org/debian-12-genericcloud-amd64.qcow2"
+  image_name  = "debian-12-genericcloud-amd64.qcow2"
+}
+```
+
+## Saídas
+- `vm_id` – ID da VM no Proxmox
+- `vm_ip` – Endereço IP configurado via Cloud-Init

--- a/terraform/modules/vm-qemu/README.md
+++ b/terraform/modules/vm-qemu/README.md
@@ -25,6 +25,7 @@ module "vm_qemu" {
   user         = "debian"
   image_url    = "https://cloud-images.debian.org/debian-12-genericcloud-amd64.qcow2"
   image_name   = "debian-12-genericcloud-amd64.qcow2"
+  image_sha256 = "<sha256>"
 }
 ```
 
@@ -67,6 +68,7 @@ module "vm_qemu" {
   user        = "debian"
   image_url   = "https://cloud-images.debian.org/debian-12-genericcloud-amd64.qcow2"
   image_name  = "debian-12-genericcloud-amd64.qcow2"
+  image_sha256 = "<sha256>"
 }
 ```
 

--- a/terraform/modules/vm-qemu/main.tf
+++ b/terraform/modules/vm-qemu/main.tf
@@ -74,9 +74,9 @@ resource "null_resource" "vm" {
   }
 
   connection {
-    type     = "ssh"
-    host     = var.pm_host
-    user     = var.pm_user
-    password = var.pm_password
+    type        = "ssh"
+    host        = var.pm_host
+    user        = var.pm_user
+    private_key = var.ssh_private_key
   }
 }

--- a/terraform/modules/vm-qemu/main.tf
+++ b/terraform/modules/vm-qemu/main.tf
@@ -1,0 +1,62 @@
+locals {
+  user_data = templatefile("${path.module}/templates/user-data.tpl", {
+    user    = var.user
+    ssh_key = var.ssh_key
+  })
+
+  meta_data = templatefile("${path.module}/templates/meta-data.tpl", {
+    hostname = var.name
+  })
+
+  network_config = templatefile("${path.module}/templates/network-config.tpl", {
+    net_name   = var.net_name
+    ip_address = var.ip_address
+    cidr       = var.cidr
+    gateway    = var.gateway
+  })
+}
+
+resource "null_resource" "vm" {
+  triggers = {
+    vmid = var.vmid
+  }
+
+  provisioner "file" {
+    content     = local.user_data
+    destination = "/tmp/${var.name}-user-data"
+  }
+
+  provisioner "file" {
+    content     = local.meta_data
+    destination = "/tmp/${var.name}-meta-data"
+  }
+
+  provisioner "file" {
+    content     = local.network_config
+    destination = "/tmp/${var.name}-network-config"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -e",
+      "ISO_DIR=/var/lib/vz/template/iso",
+      "IMG=$ISO_DIR/${var.image_name}",
+      "[ -f \"$IMG\" ] || wget -O \"$IMG\" ${var.image_url}",
+      "qm destroy ${var.vmid} --purge || true",
+      "qm create ${var.vmid} --name ${var.name} --memory ${var.memory} --cores ${var.cores} --net0 virtio,bridge=${var.bridge} --scsihw virtio-scsi-pci",
+      "qm importdisk ${var.vmid} $IMG ${var.storage}",
+      "qm set ${var.vmid} --scsi0 ${var.storage}:vm-${var.vmid}-disk-0",
+      "qm resize ${var.vmid} scsi0 ${var.disk_size}",
+      "cloud-localds $ISO_DIR/${var.name}-seed.iso /tmp/${var.name}-user-data /tmp/${var.name}-meta-data --network-config=/tmp/${var.name}-network-config",
+      "qm set ${var.vmid} --boot c --bootdisk scsi0 --ide2 local:iso/${var.name}-seed.iso,media=cdrom --serial0 socket --vga serial0",
+      "qm start ${var.vmid}"
+    ]
+  }
+
+  connection {
+    type     = "ssh"
+    host     = var.pm_host
+    user     = var.pm_user
+    password = var.pm_password
+  }
+}

--- a/terraform/modules/vm-qemu/outputs.tf
+++ b/terraform/modules/vm-qemu/outputs.tf
@@ -1,0 +1,9 @@
+output "vm_id" {
+  description = "ID da VM criada"
+  value       = var.vmid
+}
+
+output "vm_ip" {
+  description = "Endereço IP da VM"
+  value       = var.ip_address
+}

--- a/terraform/modules/vm-qemu/templates/meta-data.tpl
+++ b/terraform/modules/vm-qemu/templates/meta-data.tpl
@@ -1,0 +1,2 @@
+instance-id: ${hostname}
+local-hostname: ${hostname}

--- a/terraform/modules/vm-qemu/templates/network-config.tpl
+++ b/terraform/modules/vm-qemu/templates/network-config.tpl
@@ -1,0 +1,6 @@
+version: 2
+ethernets:
+  ${net_name}:
+    addresses:
+      - ${ip_address}/${cidr}
+    gateway4: ${gateway}

--- a/terraform/modules/vm-qemu/templates/user-data.tpl
+++ b/terraform/modules/vm-qemu/templates/user-data.tpl
@@ -1,0 +1,8 @@
+#cloud-config
+users:
+  - name: ${user}
+    ssh_authorized_keys:
+      - ${ssh_key}
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+ssh_pwauth: false

--- a/terraform/modules/vm-qemu/variables.tf
+++ b/terraform/modules/vm-qemu/variables.tf
@@ -1,0 +1,76 @@
+variable "pm_host" {
+  description = "Host do Proxmox para conexão SSH"
+  type        = string
+}
+
+variable "pm_user" {
+  description = "Usuário SSH"
+  type        = string
+}
+
+variable "pm_password" {
+  description = "Senha SSH"
+  type        = string
+  sensitive   = true
+}
+
+variable "name" {
+  type = string
+}
+
+variable "vmid" {
+  type = number
+}
+
+variable "cores" {
+  type = number
+}
+
+variable "memory" {
+  type = number
+}
+
+variable "disk_size" {
+  type = string
+}
+
+variable "storage" {
+  type = string
+}
+
+variable "bridge" {
+  type = string
+}
+
+variable "ip_address" {
+  type = string
+}
+
+variable "cidr" {
+  type = number
+}
+
+variable "gateway" {
+  type = string
+}
+
+variable "ssh_key" {
+  type = string
+}
+
+variable "user" {
+  type = string
+}
+
+variable "image_url" {
+  type = string
+}
+
+variable "image_name" {
+  type = string
+}
+
+variable "net_name" {
+  type    = string
+  default = "ens18"
+}

--- a/terraform/modules/vm-qemu/variables.tf
+++ b/terraform/modules/vm-qemu/variables.tf
@@ -15,62 +15,82 @@ variable "pm_password" {
 }
 
 variable "name" {
-  type = string
+  description = "The name of the VM in Proxmox"
+  type        = string
 }
 
 variable "vmid" {
-  type = number
+  description = "Unique VM ID in Proxmox"
+  type        = number
 }
 
 variable "cores" {
-  type = number
+  description = "CPU cores"
+  type        = number
 }
 
 variable "memory" {
-  type = number
+  description = "RAM in MB"
+  type        = number
 }
 
 variable "disk_size" {
-  type = string
+  description = "Disk size with unit"
+  type        = string
 }
 
 variable "storage" {
-  type = string
+  description = "Proxmox storage name"
+  type        = string
 }
 
 variable "bridge" {
-  type = string
+  description = "Network bridge"
+  type        = string
 }
 
 variable "ip_address" {
-  type = string
+  description = "Static IP"
+  type        = string
 }
 
 variable "cidr" {
-  type = number
+  description = "Subnet mask"
+  type        = number
 }
 
 variable "gateway" {
-  type = string
+  description = "Network gateway"
+  type        = string
 }
 
 variable "ssh_key" {
-  type = string
+  description = "Public SSH key"
+  type        = string
 }
 
 variable "user" {
-  type = string
+  description = "Username to create"
+  type        = string
 }
 
 variable "image_url" {
-  type = string
+  description = "Cloud image download URL"
+  type        = string
 }
 
 variable "image_name" {
-  type = string
+  description = "Local image filename"
+  type        = string
+}
+
+variable "image_sha256" {
+  description = "SHA256 checksum of the cloud image"
+  type        = string
 }
 
 variable "net_name" {
-  type    = string
-  default = "ens18"
+  description = "Network interface name"
+  type        = string
+  default     = "ens18"
 }


### PR DESCRIPTION
## Summary
- ajusta módulo vm-qemu para criar VM sem template utilizando null_resource e SSH
- inclui templates de cloud-init para user-data, meta-data e network

## Testing
- `terraform fmt -recursive` *(fail: command not found)*
- `apt-get update` *(fail: 403 Forbidden for ubuntu repositories)*
- `apt-get install -y terraform` *(fail: unable to locate package)*
- `terraform -chdir=terraform/modules/vm-qemu init -backend=false` *(fail: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ca7ce4948331986f59a099517443