### PR TITLE
Refactor VM template creation with Proxmox download_file

### DIFF
--- a/terraform/modules/vm-qemu/README.md
+++ b/terraform/modules/vm-qemu/README.md
@@ -1,67 +1,20 @@
 # Módulo Terraform: vm-qemu
 
-Cria uma VM no Proxmox a partir de uma imagem cloud baixada no momento do `apply`, gerando automaticamente um ISO de Cloud-Init para configuração inicial.
-
-Requer que o host Proxmox tenha o utilitário `cloud-localds` instalado.
+Cria um *template* de VM no Proxmox a partir de uma imagem cloud. O download da imagem é feito via recurso `proxmox_virtual_environment_download_file` e a configuração inicial é aplicada através de Cloud-Init usando snippets.
 
 ## Exemplo de uso
 ```hcl
 module "vm_qemu" {
-  source       = "./modules/vm-qemu"
-  pm_host      = "192.168.1.10"
-  pm_user      = "root"
-  pm_password  = var.pm_password
-  name         = "servidor01"
-  vmid         = 101
-  cores        = 2
-  memory       = 2048
-  disk_size    = "20G"
-  storage      = "local-lvm"
-  bridge       = "vmbr0"
-  ip_address   = "192.168.1.50"
-  cidr         = 24
-  gateway      = "192.168.1.1"
-  ssh_key      = file("~/.ssh/id_rsa.pub")
-  user         = "debian"
-  image_url    = "https://cloud-images.debian.org/debian-12-genericcloud-amd64.qcow2"
-  image_name   = "debian-12-genericcloud-amd64.qcow2"
-  image_sha256 = "<sha256>"
-}
-```
-
-## Criando várias VMs
-É possível definir um conjunto de VMs em um `local` e criar todas com `for_each`:
-
-```hcl
-locals {
-  vms = {
-    srv1 = {
-      name       = "srv1"
-      vmid       = 101
-      ip_address = "192.168.1.51"
-    }
-    srv2 = {
-      name       = "srv2"
-      vmid       = 102
-      ip_address = "192.168.1.52"
-    }
-  }
-}
-
-module "vm_qemu" {
-  for_each    = local.vms
   source      = "./modules/vm-qemu"
-  pm_host     = "192.168.1.10"
-  pm_user     = "root"
-  pm_password = var.pm_password
-  name        = each.value.name
-  vmid        = each.value.vmid
+  node_name   = "pve"
+  name        = "debian-template"
+  vmid        = 101
   cores       = 2
   memory      = 2048
-  disk_size   = "20G"
+  disk_size   = 20
   storage     = "local-lvm"
   bridge      = "vmbr0"
-  ip_address  = each.value.ip_address
+  ip_address  = "192.168.1.50"
   cidr        = 24
   gateway     = "192.168.1.1"
   ssh_key     = file("~/.ssh/id_rsa.pub")
@@ -73,5 +26,5 @@ module "vm_qemu" {
 ```
 
 ## Saídas
-- `vm_id` – ID da VM no Proxmox
+- `vm_id` – ID da VM criada
 - `vm_ip` – Endereço IP configurado via Cloud-Init

--- a/terraform/modules/vm-qemu/templates/meta-data.tpl
+++ b/terraform/modules/vm-qemu/templates/meta-data.tpl
@@ -1,2 +1,0 @@
-instance-id: ${hostname}
-local-hostname: ${hostname}

--- a/terraform/modules/vm-qemu/templates/network-config.tpl
+++ b/terraform/modules/vm-qemu/templates/network-config.tpl
@@ -1,6 +1,0 @@
-version: 2
-ethernets:
-  ${net_name}:
-    addresses:
-      - ${ip_address}/${cidr}
-    gateway4: ${gateway}

--- a/terraform/modules/vm-qemu/variables.tf
+++ b/terraform/modules/vm-qemu/variables.tf
@@ -1,17 +1,6 @@
-variable "pm_host" {
-  description = "Host do Proxmox para conexão SSH"
+variable "node_name" {
+  description = "Proxmox node name"
   type        = string
-}
-
-variable "pm_user" {
-  description = "Usuário SSH"
-  type        = string
-}
-
-variable "pm_password" {
-  description = "Senha SSH"
-  type        = string
-  sensitive   = true
 }
 
 variable "name" {
@@ -35,8 +24,8 @@ variable "memory" {
 }
 
 variable "disk_size" {
-  description = "Disk size with unit"
-  type        = string
+  description = "Disk size in gigabytes"
+  type        = number
 }
 
 variable "storage" {
@@ -87,10 +76,4 @@ variable "image_name" {
 variable "image_sha256" {
   description = "SHA256 checksum of the cloud image"
   type        = string
-}
-
-variable "net_name" {
-  description = "Network interface name"
-  type        = string
-  default     = "ens18"
 }


### PR DESCRIPTION
## Summary
- create VM template using `proxmox_virtual_environment_download_file` and Cloud-Init snippets
- streamline module variables for Proxmox API usage
- update documentation for new template workflow

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false` *(fails: Failed to query available provider packages)*
- `terraform validate` *(fails: Missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68c719806a84833194c5589086915ec9